### PR TITLE
Changed password-generation method for DB and secret key

### DIFF
--- a/lesspass.sh
+++ b/lesspass.sh
@@ -12,8 +12,8 @@ cd $OUTPUT_DIR
 
 curl -o docker-compose.yml https://raw.githubusercontent.com/lesspass/lesspass/master/docker-compose.prod.yml
 
-DATABASE_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32)
-SECRET_KEY=$(date +%s | sha256sum | base64 | head -c 32)
+DATABASE_PASSWORD=$(LC_ALL=C tr -dc A-Za-z0-9_ </dev/urandom | head -c 32)
+SECRET_KEY=$(LC_ALL=C tr -dc A-Za-z0-9_ </dev/urandom | head -c 32)
 
 echo "Please enter your domain name: "
 read DOMAIN


### PR DESCRIPTION
The date-method you've used is okay for unique passwords but they're not random, but a truly good passwort has to be. Therefore i propose this PR which uses the systems random pool to generate the same 32 char long passwords - but now they're not just unique but also random. Also as an additional password enhancement i've added the underline to the possible password (harder to crack).

I've successfully tested this new method on Debian and macOS Sierra. This should work on almost all Linux/Unix systems.

To mention the LC_ALL=C thing. This is sometimes necessary for `tr` to work. Otherwise you can get an `tr: Illegal byte sequence` on macOS systems.