### PR TITLE
Use links

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
       - '8000'
     volumes:
       - www:/backend/www
-    depends_on:
+    links:
       - db
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./backend
     expose:
       - '8000'
-    depends_on:
+    links:
       - db
     volumes:
       - ./backend:/backend


### PR DESCRIPTION
`backend` didn't start up correctly because it couldn't find `db`. Fixed by using `links` instead of `depends_on`.

note: I'm using `network_mode: "bridge"` for services, maybe that it the reason it didn't work with depends_on