### PR TITLE
Allow lesspass.sh to take the domain as argument

### DIFF
--- a/lesspass.sh
+++ b/lesspass.sh
@@ -15,8 +15,13 @@ curl -o docker-compose.yml https://raw.githubusercontent.com/lesspass/lesspass/m
 DATABASE_PASSWORD=$(LC_ALL=C tr -dc A-Za-z0-9_ </dev/urandom | head -c 32)
 SECRET_KEY=$(LC_ALL=C tr -dc A-Za-z0-9_ </dev/urandom | head -c 32)
 
-echo "Please enter your domain name: "
-read DOMAIN
+if [ "$#" -eq  "1" ]
+then
+    DOMAIN=$1
+else
+    echo "Please enter your domain name: "
+    read DOMAIN
+fi
 
 # create env file
 cat >> .env << EOF

--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,9 @@ LessPass open source password manager (https://lesspass.com)
 
 simply run 
 
-    bash <(curl -s https://raw.githubusercontent.com/lesspass/lesspass/master/lesspass.sh)
+    bash <(curl -s https://raw.githubusercontent.com/lesspass/lesspass/master/lesspass.sh) [DOMAIN]
 
+You can specify your domain (eg example.com). If not provided, you'll be asked to enter it.
 
 ## Status
 


### PR DESCRIPTION
I suggest to allow lesspass installation script to take the requested domain as parameter so that it can be installed in a non interactive way.