### PR TITLE
Adds an argument to prompt for the [SITE] and [LOGIN] arguments

### DIFF
--- a/cli/lesspass/cli.py
+++ b/cli/lesspass/cli.py
@@ -21,6 +21,7 @@ def parse_args(args):
     parser.add_argument("--no-symbols", dest="ns", action="store_true")
     parser.add_argument("-L", "--length", default=16, type=int)
     parser.add_argument("-C", "--counter", default=1, type=int)
+    parser.add_argument("-p", "--prompt", action="store_true")
     parser.add_argument(
         "-c", "--copy", "--clipboard", dest="clipboard", action="store_true"
     )

--- a/cli/lesspass/cli.py
+++ b/cli/lesspass/cli.py
@@ -21,7 +21,7 @@ def parse_args(args):
     parser.add_argument("--no-symbols", dest="ns", action="store_true")
     parser.add_argument("-L", "--length", default=16, type=int)
     parser.add_argument("-C", "--counter", default=1, type=int)
-    parser.add_argument("-p", "--prompt", action="store_true")
+    parser.add_argument("-p", "--prompt", dest="prompt", action="store_true")
     parser.add_argument(
         "-c", "--copy", "--clipboard", dest="clipboard", action="store_true"
     )

--- a/cli/lesspass/core.py
+++ b/cli/lesspass/core.py
@@ -26,10 +26,8 @@ def main(args=sys.argv[1:]):
         sys.exit(0)
     profile, master_password = create_profile(args)
 
-    if not profile["site"] and args.prompt:
+    if args.prompt:
         profile["site"] = getpass.getpass("Site: ")
-
-    if not profile["login"] and args.prompt:
         profile["login"] = getpass.getpass("Login: ")
 
     if not master_password:

--- a/cli/lesspass/core.py
+++ b/cli/lesspass/core.py
@@ -25,9 +25,18 @@ def main(args=sys.argv[1:]):
         print_help(help_message)
         sys.exit(0)
     profile, master_password = create_profile(args)
+
+    if not profile["site"] and args.prompt:
+        profile["site"] = getpass.getpass("Site: ")
+
+    if not profile["login"] and args.prompt:
+        profile["login"] = getpass.getpass("Login: ")
+
     if not master_password:
         master_password = getpass.getpass("Master Password: ")
+
     generated_password = generate_password(profile, master_password)
+
     if args.clipboard:
         try:
             copy(generated_password)

--- a/cli/lesspass/help.py
+++ b/cli/lesspass/help.py
@@ -33,7 +33,7 @@ Options:
   -s, --symbols        add symbols in password
   -L, --length         int (default 16)
   -C, --counter        int (default 1)
-  -p, --prompt         prompt user for [SITE] and [LOGIN] arguments
+  -p, --prompt         interactively prompt SITE and LOGIN (prevent leak to shell history)
   --no-lowercase       remove lowercase from password
   --no-uppercase       remove uppercase from password
   --no-digits          remove digits from password

--- a/cli/lesspass/help.py
+++ b/cli/lesspass/help.py
@@ -12,8 +12,8 @@ def get_long_help():
     return """Name:
 
   LessPass - stateless password generator
-    
-Usage: 
+
+Usage:
 
   lesspass SITE [LOGIN] [MASTER_PASSWORD] [OPTIONS]
 
@@ -33,6 +33,7 @@ Options:
   -s, --symbols        add symbols in password
   -L, --length         int (default 16)
   -C, --counter        int (default 1)
+  -p, --prompt         prompt user for [SITE] and [LOGIN] arguments
   --no-lowercase       remove lowercase from password
   --no-uppercase       remove uppercase from password
   --no-digits          remove digits from password

--- a/cli/lesspass/validator.py
+++ b/cli/lesspass/validator.py
@@ -39,7 +39,7 @@ class DefaultParameters(object):
     def is_valid(self):
         is_valid = True
         if not self.args.site and not self.args.prompt:
-            self.error_message += " * SITE is a required argument"
+            self.error_message += " * SITE is a required argument (unless in interactive mode with --prompt)"
             is_valid = False
         return is_valid
 

--- a/cli/lesspass/validator.py
+++ b/cli/lesspass/validator.py
@@ -38,7 +38,7 @@ class DefaultParameters(object):
 
     def is_valid(self):
         is_valid = True
-        if not self.args.site:
+        if not self.args.site and not self.args.prompt:
             self.error_message += " * SITE is a required argument"
             is_valid = False
         return is_valid

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -110,3 +110,9 @@ class TestParseArgs(unittest.TestCase):
 
     def test_parse_args_clipboard_backward_compatibility(self):
         self.assertTrue(parse_args(["site", "--clipboard"]).clipboard)
+
+    def test_parse_args_prompt(self):
+        self.assertTrue(parse_args(["--prompt"]).prompt)
+
+    def test_parse_args_prompt_short(self):
+        self.assertTrue(parse_args(["-p"]).prompt)

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -111,7 +111,7 @@ class TestParseArgs(unittest.TestCase):
     def test_parse_args_clipboard_backward_compatibility(self):
         self.assertTrue(parse_args(["site", "--clipboard"]).clipboard)
 
-    def test_parse_args_prompt(self):
+    def test_parse_args_prompt_long(self):
         self.assertTrue(parse_args(["--prompt"]).prompt)
 
     def test_parse_args_prompt_short(self):

--- a/cli/tests/test_validator.py
+++ b/cli/tests/test_validator.py
@@ -50,3 +50,10 @@ class TestValidateArgs(unittest.TestCase):
         self.assertTrue(
             "SITE is a required argument" in message
         )
+
+    def test_validate_args_site_optional_with_prompt(self):
+        error, message = validate_args(parse_args(["--prompt"]))
+        self.assertFalse(error)
+        self.assertTrue(
+            "SITE is a required argument" not in message
+        )


### PR DESCRIPTION
For added security, this PR provides a [-p --prompt] argument which then allows a user to enter both the SITE and LOGIN arguments in the same manner they could enter the MASTER PASSWORD - without revealing their values in a terminal buffer, or recording them in bash history.

Usage:
```
$ lesspass -p -L 25
Site: 
Login: 
Master Password: 
ybnAY]&S?Vx\8L,96u!_?,;>J
```
