### PR TITLE
Handle keyboard interrupts to abort gracefully

### DIFF
--- a/cli/lesspass/core.py
+++ b/cli/lesspass/core.py
@@ -2,6 +2,7 @@ import getpass
 import platform
 import sys
 import traceback
+import signal
 
 from lesspass.version import __version__
 from lesspass.cli import parse_args
@@ -11,6 +12,7 @@ from lesspass.profile import create_profile
 from lesspass.password import generate_password
 from lesspass.clipboard import copy
 
+signal.signal(signal.SIGINT, lambda s, f: sys.exit(0))
 
 def main(args=sys.argv[1:]):
     args = parse_args(args)


### PR DESCRIPTION
I find myself fat fingering inputs when interactively entering site/login/password.  Often it's quicker and easier to Ctrl+C out of the prompt and start over.  Doing so dumps the KeyboardInterrupt stacktrace in all its fine form to the terminal.

This PR simply handles the SIGINT and exits gracefully without all the clutter.

Note: I haven't added a unittest (yet<sup>1</sup>) - I'm not certain one would be required for this PR?

<sup>1</sup> I was thinking about adding a new test class, `test_interaction.py` exposing a `TestInteraction` class.  From this I was thinking about firing off `lesspass.core:main` using different parameters in a forked process and validate STDOUT against known quantities.  For this use case, I think we could test the keyboard interrupt on `--prompt` and confirm STDOUT is empty.

Unless there is a better way to test SIGINTs terminating the process?