### PR TITLE
adding help text clarity around supported max-length

### DIFF
--- a/cli/lesspass/help.py
+++ b/cli/lesspass/help.py
@@ -31,7 +31,7 @@ Options:
   -u, --uppercase      add uppercase in password
   -d, --digits         add digits in password
   -s, --symbols        add symbols in password
-  -L, --length         int (default 16)
+  -L, --length         int (default 16, max 35)
   -C, --counter        int (default 1)
   -p, --prompt         interactively prompt SITE and LOGIN (prevent leak to shell history)
   --no-lowercase       remove lowercase from password


### PR DESCRIPTION
Fixes #390 

Nothing major going on here, just a quick clarification that the possible length is capped at 35. I'll look further to investigate why the additional `a` is being appended to make up for the length, but for now this should suffice.