### PR TITLE
Add a --to-profiles CLI option to save profiles

### DIFF
--- a/cli/lesspass/cli.py
+++ b/cli/lesspass/cli.py
@@ -2,6 +2,21 @@ import argparse
 import os
 
 
+class readable_dir(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        prospective_dir = values
+        if not os.path.isdir(prospective_dir):
+            raise argparse.ArgumentTypeError(
+                f"readable_dir: `{prospective_dir}` is not a valid path"
+            )
+        if os.access(prospective_dir, os.R_OK):
+            setattr(namespace, self.dest, prospective_dir)
+        else:
+            raise argparse.ArgumentTypeError(
+                f"readable_dir: `{prospective_dir}` is not a readable dir"
+            )
+
+
 def parse_args(args):
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("site", nargs="?")
@@ -22,6 +37,9 @@ def parse_args(args):
     parser.add_argument("-L", "--length", default=16, type=int)
     parser.add_argument("-C", "--counter", default=1, type=int)
     parser.add_argument("-p", "--prompt", dest="prompt", action="store_true")
+    parser.add_argument(
+        "--to-profiles", dest="to_profiles", action=readable_dir
+    )
     parser.add_argument(
         "-c", "--copy", "--clipboard", dest="clipboard", action="store_true"
     )

--- a/cli/lesspass/cli.py
+++ b/cli/lesspass/cli.py
@@ -7,13 +7,13 @@ class readable_dir(argparse.Action):
         prospective_dir = values
         if not os.path.isdir(prospective_dir):
             raise argparse.ArgumentTypeError(
-                f"readable_dir: `{prospective_dir}` is not a valid path"
+                "readable_dir: `{}` is not a valid path".format(prospective_dir)
             )
         if os.access(prospective_dir, os.R_OK):
             setattr(namespace, self.dest, prospective_dir)
         else:
             raise argparse.ArgumentTypeError(
-                f"readable_dir: `{prospective_dir}` is not a readable dir"
+                "readable_dir: `{}` is not a readable dir".format(prospective_dir)
             )
 
 

--- a/cli/lesspass/core.py
+++ b/cli/lesspass/core.py
@@ -8,11 +8,12 @@ from lesspass.version import __version__
 from lesspass.cli import parse_args
 from lesspass.help import print_help
 from lesspass.validator import validate_args
-from lesspass.profile import create_profile
+from lesspass.profile import create_profile, save_profile
 from lesspass.password import generate_password
 from lesspass.clipboard import copy
 
 signal.signal(signal.SIGINT, lambda s, f: sys.exit(0))
+
 
 def main(args=sys.argv[1:]):
     args = parse_args(args)
@@ -52,6 +53,10 @@ def main(args=sys.argv[1:]):
             print("-" * 80)
     else:
         print(generated_password)
+
+    if args.to_profiles:
+        save_profile(profile, args.to_profiles)
+
 
 if __name__ == '__main__':
     main()

--- a/cli/lesspass/help.py
+++ b/cli/lesspass/help.py
@@ -41,6 +41,7 @@ Options:
   -c, --clipboard      copy generated password to clipboard rather than displaying it.
                        Need pbcopy (OSX), xsel or xclip (Linux) or clip (Windows).
   -v, --version        lesspass version number
+  --to-profiles DIR    allow to store profiles in the target `DIR` directory
 
 Examples:
 

--- a/cli/lesspass/profile.py
+++ b/cli/lesspass/profile.py
@@ -1,9 +1,14 @@
+import json
+from pathlib import Path
+from urllib.parse import quote_plus
+
+
 def create_profile(args):
     profile = {
         "lowercase": False if args.nl else True,
         "uppercase": False if args.nu else True,
-        "digits":  False if args.nd else True,
-        "symbols":  False if args.ns else True,
+        "digits": False if args.nd else True,
+        "symbols": False if args.ns else True,
         "length": args.length,
         "counter": args.counter,
         "site": args.site,
@@ -15,3 +20,10 @@ def create_profile(args):
         profile["digits"] = args.d
         profile["symbols"] = args.s
     return profile, args.master_password
+
+
+def save_profile(profile, folder):
+    profile_filepath = Path(folder) / f"{quote_plus(profile['site'])}.json"
+    with open(profile_filepath, "w") as target:
+        target.write(json.dumps(profile, indent=4))
+        print(f"Profile saved to {profile_filepath}")

--- a/cli/lesspass/profile.py
+++ b/cli/lesspass/profile.py
@@ -23,7 +23,7 @@ def create_profile(args):
 
 
 def save_profile(profile, folder):
-    profile_filepath = Path(folder) / f"{quote_plus(profile['site'])}.json"
+    profile_filepath = Path(folder) / "{}.json".format(quote_plus(profile["site"]))
     with open(profile_filepath, "w") as target:
         target.write(json.dumps(profile, indent=4))
-        print(f"Profile saved to {profile_filepath}")
+        print("Profile saved to {}".format(profile_filepath))

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,5 +1,5 @@
 import unittest
-
+import tempfile
 from mock import patch
 
 from lesspass.cli import parse_args
@@ -116,3 +116,8 @@ class TestParseArgs(unittest.TestCase):
 
     def test_parse_args_prompt_short(self):
         self.assertTrue(parse_args(["-p"]).prompt)
+
+    def test_parse_args_to_profiles_long(self):
+        self.assertTrue(
+            parse_args(["--to-profiles", tempfile.mkdtemp()]).to_profiles
+        )

--- a/cli/tests/test_profile.py
+++ b/cli/tests/test_profile.py
@@ -1,7 +1,11 @@
+import json
 import unittest
+from tempfile import mkdtemp
+from os import listdir
+from pathlib import Path
 
 from lesspass.cli import parse_args
-from lesspass.profile import create_profile
+from lesspass.profile import create_profile, save_profile
 
 
 class TestProfile(unittest.TestCase):
@@ -167,3 +171,12 @@ class TestProfile(unittest.TestCase):
         self.assertTrue(profile["uppercase"])
         self.assertTrue(profile["digits"])
         self.assertFalse(profile["symbols"])
+
+    def test_save_profile(self):
+        profile, master_password = create_profile(parse_args(["site", "login"]))
+        temp_dir = mkdtemp()
+        save_profile(profile, temp_dir)
+        profile_filename = f"{profile['site']}.json"
+        self.assertIn(profile_filename, listdir(temp_dir))
+        with open(Path(temp_dir) / profile_filename) as saved_profile:
+            self.assertEqual(profile, json.loads(saved_profile.read()))

--- a/cli/tests/test_profile.py
+++ b/cli/tests/test_profile.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from tempfile import mkdtemp
+from tempfile import TemporaryDirectory
 from os import listdir
 from pathlib import Path
 
@@ -174,9 +174,9 @@ class TestProfile(unittest.TestCase):
 
     def test_save_profile(self):
         profile, master_password = create_profile(parse_args(["site", "login"]))
-        temp_dir = mkdtemp()
-        save_profile(profile, temp_dir)
-        profile_filename = "{}.json".format(profile["site"])
-        self.assertIn(profile_filename, listdir(temp_dir))
-        with open(Path(temp_dir) / profile_filename) as saved_profile:
-            self.assertEqual(profile, json.loads(saved_profile.read()))
+        with TemporaryDirectory() as temp_dir:
+            save_profile(profile, temp_dir)
+            profile_filename = "{}.json".format(profile["site"])
+            self.assertIn(profile_filename, listdir(temp_dir))
+            with open(Path(temp_dir) / profile_filename) as saved_profile:
+                self.assertEqual(profile, json.loads(saved_profile.read()))

--- a/cli/tests/test_profile.py
+++ b/cli/tests/test_profile.py
@@ -176,7 +176,7 @@ class TestProfile(unittest.TestCase):
         profile, master_password = create_profile(parse_args(["site", "login"]))
         temp_dir = mkdtemp()
         save_profile(profile, temp_dir)
-        profile_filename = f"{profile['site']}.json"
+        profile_filename = "{}.json".format(profile["site"])
         self.assertIn(profile_filename, listdir(temp_dir))
         with open(Path(temp_dir) / profile_filename) as saved_profile:
             self.assertEqual(profile, json.loads(saved_profile.read()))


### PR DESCRIPTION
Refs #396

This option is the first step toward having imports/exports of profiles when using the command-line interface.

For instance `lesspass site login --to-profiles profiles/` will generate a `profiles/site.json` file containing the whole profile.