### PR TITLE
fix bug preventing the usage of --prompt

### DIFF
--- a/cli/lesspass/cli.py
+++ b/cli/lesspass/cli.py
@@ -37,7 +37,11 @@ def parse_args(args):
     parser.add_argument(
         "-v", "--version", action="version", version=version.__version__
     )
-    parser.add_argument("site", help="site used in the password generation (required)")
+    parser.add_argument(
+        "site",
+        nargs="?",
+        help="site used in the password generation (required)"
+    )
     parser.add_argument(
         "login", nargs="?", help="login used in the password generation. Default to ''."
     )

--- a/cli/lesspass/core.py
+++ b/cli/lesspass/core.py
@@ -25,12 +25,12 @@ def main(args=sys.argv[1:]):
     if args.prompt:
         args.site = getpass.getpass("Site: ")
         args.login = getpass.getpass("Login: ")
-    if not args.master_password:
-        args.master_password = getpass.getpass("Master Password: ")
-
     if not args.site:
         print("ERROR argument SITE is required but was not provided.")
         sys.exit(4)
+
+    if not args.master_password:
+        args.master_password = getpass.getpass("Master Password: ")
     if not args.master_password:
         print("ERROR argument MASTER_PASSWORD is required but was not provided")
         sys.exit(5)


### PR DESCRIPTION
@guillaumevincent Thanks for your assistance working with me on #395!

A bug has been introduced in the formatting commit that prevents us from using the `--prompt` flag.

```shell
$ lesspass --version
7.0.0

$ lesspass --prompt
usage: lesspass SITE [LOGIN] [MASTER_PASSWORD] [OPTIONS]
lesspass: error: the following arguments are required: site
```

This is because of the removal of `nargs=` [here](https://github.com/lesspass/lesspass/commit/b310f00cb8610f7a3ceb252b4fae885dbe6382cb#diff-8c53b6fdc68a0ec41b6e1ba38f7247ddR40). In my initial testing I had also removed it, but I [noted](https://github.com/lesspass/lesspass/commit/cb360754f192d4cdf1a114a6788049649c1a7d8d#diff-8c53b6fdc68a0ec41b6e1ba38f7247ddR42) that removing it caused an issue with the CLI being expected to accept a SITE via `--prompt`  and returned it. 

Because we override the help usage, this requirement of SITE is declared clearly in my opinion as we do not enclose SITE in square brackets `[]`:

```$ lesspass --help | head -1
usage: lesspass SITE [LOGIN] [MASTER_PASSWORD] [OPTIONS]
```

This PR re-adds nargs, and also moves the testing logic around evaluating if SITE has been received by the CLI so that we don't unnecessarily prompt for a master password if we don't receive SITE either via the CLI or via `--prompt`.
