### PR TITLE
Allow the browser to dynamically resize the popup window

### DIFF
--- a/packages/lesspass-web-extension/extension/popup.html
+++ b/packages/lesspass-web-extension/extension/popup.html
@@ -9,7 +9,7 @@
   <style>
     body {
       width: 420px;
-      height: 460px;
+      height: auto;
     }
 
     .loading {


### PR DESCRIPTION
This prevents scroll bars from appearing when options are displayed on the main screen.

Quick preview of all the views on chrome/firefox:

![2019-06-01-165532_1002x395_scrot](https://user-images.githubusercontent.com/4571394/58753535-77b3b800-848e-11e9-9b55-20cbd5230797.png)
![2019-06-01-165614_1000x508_scrot](https://user-images.githubusercontent.com/4571394/58753536-77b3b800-848e-11e9-9686-9c5084d1d442.png)
![2019-06-01-165626_965x365_scrot](https://user-images.githubusercontent.com/4571394/58753537-77b3b800-848e-11e9-9061-3c860c66969c.png)



