### PR TITLE
Fixing en/de mismatch with LengthDeprecationWarning

### DIFF
--- a/containers/frontend/dist/i18n/de.json
+++ b/containers/frontend/dist/i18n/de.json
@@ -13,7 +13,7 @@
   "ForgotPassword": "Passwort vergessen?",
   "Generate": "Erstelle",
   "Length": "Länge",
-  "LengthDeprecationWarning": "The maximum length of a password is 35 characters.",
+  "LengthDeprecationWarning": "Die maximale Länge eines Passwortes beträgt 35 Zeichen.",
   "LessPass Database Url": "LessPass Datenbank Url",
   "Login": "Login",
   "LoginFormInvalid": "LessPass URL, email-Adresse und Passwort sind obligatorisch",

--- a/containers/frontend/dist/i18n/en.json
+++ b/containers/frontend/dist/i18n/en.json
@@ -13,7 +13,7 @@
   "ForgotPassword": "Forgot your password?",
   "Generate": "Generate",
   "Length": "Length",
-  "LengthDeprecationWarning": "Die maximale Länge eines Passwortes beträgt 35 Zeichen.",
+  "LengthDeprecationWarning": "The maximum length of a password is 35 characters.",
   "LessPass Database Url": "LessPass Database Url",
   "Login": "Login",
   "LoginFormInvalid": "LessPass URL, email, and password are mandatory",


### PR DESCRIPTION
It looks like de and en translations are mixed with "LengthDeprecationWarning" variable.