### PR TITLE
Add timeout for share password profile popup

### DIFF
--- a/packages/lesspass-pure/src/views/PasswordGenerator.vue
+++ b/packages/lesspass-pure/src/views/PasswordGenerator.vue
@@ -252,11 +252,9 @@ export default {
           "PasswordProfileCopied",
           "Your password profile has been copied"
         );
-        showTooltip(
-          document.getElementById("sharePasswordProfileButton"),
-          copySuccessMessage,
-          "left"
-        );
+        const element = document.getElementById("sharePasswordProfileButton");
+        showTooltip(element, copySuccessMessage, "left");
+        setTimeout(() => hideTooltip(element), 2000);
       } else {
         message.warning(
           this.$t(


### PR DESCRIPTION
closes: #431 

The issue seemed to be caused by a missing timeout to hide the tooltip element. For the fix, I just followed the format for hiding the tooltip [a few lines above](https://github.com/lesspass/lesspass/blob/master/packages/lesspass-pure/src/views/PasswordGenerator.vue#L238). 

Before:
![before](https://user-images.githubusercontent.com/39106297/59967617-1d04fd80-951c-11e9-8952-5fca5dddad93.gif)

After:
![after](https://user-images.githubusercontent.com/39106297/59967619-21311b00-951c-11e9-9547-bf81b36df7d9.gif)

I didn't include changes to [`lesspass-web-extension/extension/dist/lesspass.min.js`](https://github.com/lesspass/lesspass/blob/master/packages/lesspass-web-extension/extension/dist/lesspass.min.js), but let me know if I should add a commit for it.