### PR TITLE
Add longer description for Pypi docs

### DIFF
--- a/cli/lesspass/__init__.py
+++ b/cli/lesspass/__init__.py
@@ -1,2 +1,50 @@
 name = "lesspass"
 description = "LessPass is a stateless password manager."
+long_description = """Name:
+
+  LessPass - stateless password generator
+
+Usage:
+
+  lesspass SITE [LOGIN] [MASTER_PASSWORD] [OPTIONS]
+
+Arguments:
+
+  SITE                site used in the password generation (required)
+  LOGIN               login used in the password generation
+                      default to '' if not provided
+  MASTER_PASSWORD     master password used in password generation
+                      default to LESSPASS_MASTER_PASSWORD env variable or prompt
+
+Options:
+
+  -l, --lowercase      add lowercase in password
+  -u, --uppercase      add uppercase in password
+  -d, --digits         add digits in password
+  -s, --symbols        add symbols in password
+  -L, --length         int (default 16, max 35)
+  -C, --counter        int (default 1)
+  -p, --prompt         interactively prompt SITE and LOGIN (prevent leak to shell history)
+  --no-lowercase       remove lowercase from password
+  --no-uppercase       remove uppercase from password
+  --no-digits          remove digits from password
+  --no-symbols         remove symbols from password
+  -c, --clipboard      copy generated password to clipboard rather than displaying it.
+                       Need pbcopy (OSX), xsel or xclip (Linux) or clip (Windows).
+  -v, --version        lesspass version number
+
+Examples:
+
+  # no symbols
+  lesspass site login masterpassword --no-symbols
+  # no symbols shortcut
+  lesspass site login masterpassword -lud
+  # only digits and length of 8
+  lesspass site login masterpassword -d -L8
+  # master password in env variable
+  LESSPASS_MASTER_PASSWORD="masterpassword" lesspass site login
+
+Copyright:
+
+  Copyright © 2018 Guillaume Vincent <contact@lesspass.com>.  License GPLv3: GNU GPL version 3 <https://gnu.org/licenses/gpl.html>.
+  This is free software: you are free to change and redistribute it.  There is NO WARRANTY, to the extent permitted by law."""

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 from lesspass.version import __version__
-from lesspass import description
+from lesspass import long_description
 
 
 setuptools.setup(
@@ -11,7 +11,7 @@ setuptools.setup(
     author='Guillaume Vincent',
     author_email='contact@lesspass.com',
     description='LessPass stateless password generator',
-    long_description=description,
+    long_description=long_description,
     install_requires=[],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
Potential fix for #405. Looks like the longer description was removed in #395, which was intentional:

> A short plain-text description (defined in module `__init__`) has been added to this file to replace this entirely at the discretion of the maintainers. This will have an impact on how the package appears on PyPi, but as the text on PyPi was not monospaced, the help-output may not be best for this space anyway.

If the longer description is better for Pypi, this fix should add it back in and leave the shorter description available for use. Otherwise both this issue and #405 can be closed.
