### PR TITLE
Add explicit CLI support for wl-clipboard

### DIFF
--- a/cli/lesspass/clipboard.py
+++ b/cli/lesspass/clipboard.py
@@ -20,7 +20,7 @@ def get_system_copy_command():
     if platform.system() == "Darwin" and _copy_available("pbcopy"):
         return "pbcopy"
 
-    for command in ["xsel", "xclip"]:
+    for command in ["xsel", "xclip", "wl-copy"]:
         if _copy_available(command):
             return command
 
@@ -32,6 +32,7 @@ def _popen(args, **kwargs):
 commands = {
     "clip": ["clip"],
     "pbcopy": ["pbcopy"],
+    "wl-copy": ["wl-copy"],
     "xsel": ["xsel", "--clipboard", "--input"],
     "xclip": ["xclip", "-selection", "clipboard"],
 }

--- a/cli/lesspass/core.py
+++ b/cli/lesspass/core.py
@@ -17,8 +17,8 @@ def main(args=sys.argv[1:]):
     args = parse_args(args)
     if args.clipboard and not get_system_copy_command():
         print(
-            "ERROR To use the option -c (--copy) you need pbcopy "
-            + "on OSX, xsel or xclip on Linux, and clip on Windows"
+            "ERROR To use the option -c (--copy) you need pbcopy on OSX, "
+            + "xsel, xclip, or wl-clipboard on Linux, and clip on Windows"
         )
         sys.exit(3)
 


### PR DESCRIPTION
The lesspass CLI already supports copying to the clipboard on X
window system environments if certain tools (xsel or xclip) are
installed. Many Unix-like systems have begun shipping environments
that use Wayland instead of X. xsel and xclip are not designed for
Wayland. The most widely-used clipboard tool suite for Wayland,
wl-clipboard, has an optional compatibility layer that can make it
work with the xsel and xclip commands; this may or may not be
included in packages that provide the wl-clipboard tools.

This commit gives the lesspass CLI explicit support for the wl-copy
command provided by wl-clipboard. lesspass will continue to check
for the presence of xsel and xclip before trying wl-copy, to guard
against the perhaps unlikely scenario that the user has the wl-copy
command installed on their system, but is not running a Wayland
server, in which case the command will fail.

Addresses #491 