### PR TITLE
Check DISPLAY_WAYLAND env variable to decide whether to use wl-copy

### DIFF
--- a/cli/lesspass/clipboard.py
+++ b/cli/lesspass/clipboard.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import subprocess
 import uuid
@@ -20,7 +21,10 @@ def get_system_copy_command():
     if platform.system() == "Darwin" and _copy_available("pbcopy"):
         return "pbcopy"
 
-    for command in ["xsel", "xclip", "wl-copy"]:
+    if os.getenv("WAYLAND_DISPLAY") is not None and _copy_available("wl-copy"):
+        return "wl-copy"
+
+    for command in ["xsel", "xclip"]:
         if _copy_available(command):
             return command
 


### PR DESCRIPTION
It has been pointed out by @bugaevc that a user may have X and
Wayland software available on the same system (e.g. for testing
purposes) and that the best way to determine whether to use
xsel/xclip or wl-copy is not to merely check for the presence of
these commands, but to check whether the `WAYLAND_DISPLAY`
environment variable is set. That is what this commit does.

@guillaumevincent, we were just discussing this.