### PR TITLE
fix duplicate prompts

### DIFF
--- a/cli/lesspass/core.py
+++ b/cli/lesspass/core.py
@@ -23,14 +23,18 @@ def main(args=sys.argv[1:]):
         sys.exit(3)
 
     if args.prompt:
-        args.site = getpass.getpass("Site: ")
-        args.login = getpass.getpass("Login: ")
+        if not args.site:
+            args.site = getpass.getpass("Site: ")
+        if not args.login:
+            args.login = getpass.getpass("Login: ")
+
+    if not args.master_password:
+        args.master_password = getpass.getpass("Master Password: ")
+
     if not args.site:
         print("ERROR argument SITE is required but was not provided.")
         sys.exit(4)
 
-    if not args.master_password:
-        args.master_password = getpass.getpass("Master Password: ")
     if not args.master_password:
         print("ERROR argument MASTER_PASSWORD is required but was not provided")
         sys.exit(5)


### PR DESCRIPTION
This is a small change which reorders/consolidates how lesspass prompts the user for the required information. Before this, if a user supplied the -p tag while also providing site, login, and or a password in the positional arguments, the prompt would ask for the values again. This instead checks for the values and skips asking if they exist. For example, "lesspass sitename -p" will only prompt for the login and the password