### PR TITLE
Fix spanish translation error: changed 'Sign in' translation from 'Registrarse' to 'Ingresar'

### DIFF
--- a/packages/lesspass-pure/src/i18n/es.json
+++ b/packages/lesspass-pure/src/i18n/es.json
@@ -45,7 +45,7 @@
   "Saved passwords": "Contraseñas guardadas",
   "Search": "Buscar",
   "Settings": "Configuraciones",
-  "Sign In": "Registrarse",
+  "Sign In": "Ingresar",
   "Sign out": "Desconectar",
   "SignInInstead": "¿Ya tienes una cuenta? Iniciar sesión en su lugar",
   "Site": "Sitio",


### PR DESCRIPTION
While using the browser extension i noticed you use roughly the same spanish translation for "Sign up" and "Sign in". This is confusing because whenever i want to sign in i forget which of the two buttons is supposed to do it.

![6a794013ecf4716a103331003fc5a339](https://user-images.githubusercontent.com/1382608/90814845-1af52500-e300-11ea-8fcb-f5971afa5761.png)


So i replaced it with a far more common translation.