### PR TITLE
More robust command check for cli

### DIFF
--- a/cli/lesspass/clipboard.py
+++ b/cli/lesspass/clipboard.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import shutil
 import subprocess
 import uuid
 
@@ -11,7 +12,7 @@ def _call(args):
 def _copy_available(command):
     if platform.system() == "Windows":
         return _call(["where", command]) == 0
-    return _call(["which", command]) == 0
+    return shutil.which(command) is not None
 
 
 def get_system_copy_command():


### PR DESCRIPTION
Hi!

I've experienced some issues on Termux (Android).

After some research, I found that the use of the `which` command in `subprocess.call()` can cause some issues, as it is well explained [here](https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script):

> Avoid which. Not only is it an external process you're launching for doing very little (meaning builtins like hash, type or command are way cheaper), you can also rely on the builtins to actually do what you want, while the effects of external commands can easily vary from system to system.
>
> Why care?
> - Many operating systems have a which that doesn't even set an exit status, meaning the if which foo won't even work there and will always report that foo exists, even if it doesn't (note that some POSIX shells appear to do this for hash too).
> - Many operating systems make which do custom and evil stuff like change the output or even hook into the package manager.

So I propose to use `shutil.which()`, a built-in Python function. After some testing, I experience no issues with this function.
