### PR TITLE
Not import tty and termios when in NT os

### DIFF
--- a/cli/lesspass/fingerprint.py
+++ b/cli/lesspass/fingerprint.py
@@ -3,12 +3,13 @@ import hashlib
 import sys
 import os
 import random
-import tty
-import termios
 import threading
 
 if os.name == "nt":
     import msvcrt
+else:
+    import tty
+    import termios
 
 
 icon_names = [


### PR DESCRIPTION
Modules tty and termios will not be used in Windows.

If import tty and termios in Windows, it will raise `ModuleNotFoundError` like [lesspass#556](https://github.com/lesspass/lesspass/issues/556).