### PR TITLE
Turn off nginx server_tokens for lesspass-site

### DIFF
--- a/packages/lesspass-site/nginx.conf
+++ b/packages/lesspass-site/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen       80;
     server_name  frontend;
+    server_tokens off;
 
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;


### PR DESCRIPTION
It's suggested to minimized the unnecessary information disclosure as
part of the nginx hardening practice.

Current config will send the version of nginx in the header of every request:

```sh
$ curl -sI https://lesspass.com | grep ^Server:
Server: nginx/1.19.2
```