### PR TITLE
Enable Apache OCSP stapling

### DIFF
--- a/containers/webserver/httpd-ssl.conf
+++ b/containers/webserver/httpd-ssl.conf
@@ -100,19 +100,19 @@ SSLSessionCacheTimeout  300
 #   How-To for more information.
 #
 #   Enable stapling for all SSL-enabled servers:
-#SSLUseStapling On
+SSLUseStapling On
 
 #   Define a relatively small cache for OCSP Stapling using
 #   the same mechanism that is used for the SSL session cache
 #   above.  If stapling is used with more than a few certificates,
 #   the size may need to be increased.  (AH01929 will be logged.)
-#SSLStaplingCache "shmcb:/usr/local/apache2/logs/ssl_stapling(32768)"
+SSLStaplingCache "shmcb:/usr/local/apache2/logs/ssl_stapling(32768)"
 
 #   Seconds before valid OCSP responses are expired from the cache
-#SSLStaplingStandardCacheTimeout 3600
+SSLStaplingStandardCacheTimeout 3600
 
 #   Seconds before invalid OCSP responses are expired from the cache
-#SSLStaplingErrorCacheTimeout 600
+SSLStaplingErrorCacheTimeout 600
 
 ##
 ## SSL Virtual Host Context


### PR DESCRIPTION
This will speed up the website loading, and make the website more
reliable to the users when the client fails to connect to the CA for an
OCSP response.

Reference:
- https://en.wikipedia.org/wiki/OCSP_stapling