### PR TITLE
Enable Apache HTTP/2 for better performance

### DIFF
--- a/containers/webserver/httpd-ssl.conf
+++ b/containers/webserver/httpd-ssl.conf
@@ -114,6 +114,8 @@ SSLSessionCacheTimeout  300
 #   Seconds before invalid OCSP responses are expired from the cache
 #SSLStaplingErrorCacheTimeout 600
 
+Protocols h2 h2c http/1.1
+
 ##
 ## SSL Virtual Host Context
 ##

--- a/containers/webserver/httpd.conf
+++ b/containers/webserver/httpd.conf
@@ -164,7 +164,7 @@ LoadModule ssl_module modules/mod_ssl.so
 #LoadModule optional_fn_import_module modules/mod_optional_fn_import.so
 #LoadModule optional_fn_export_module modules/mod_optional_fn_export.so
 #LoadModule dialup_module modules/mod_dialup.so
-#LoadModule http2_module modules/mod_http2.so
+LoadModule http2_module modules/mod_http2.so
 #LoadModule proxy_http2_module modules/mod_proxy_http2.so
 #LoadModule md_module modules/mod_md.so
 #LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so


### PR DESCRIPTION
Apache start to support HTTP/2 since v2.4.17, this will make the web loading much more faster!