### PR TITLE
Minimize Apache ServerTokens for lesspass-site

### DIFF
--- a/containers/webserver/Dockerfile
+++ b/containers/webserver/Dockerfile
@@ -1,6 +1,8 @@
 FROM httpd:2.4
 LABEL maintainer="LessPass <contact@lesspass.com>"
 LABEL name="LessPass Web Server" 
+
+RUN sed -i 's/ServerTokens Full/ServerTokens Prod/g' /usr/local/apache2/conf/extra/httpd-default.conf
 COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf
 COPY ./httpd-ssl.conf /usr/local/apache2/conf/extra/httpd-ssl.conf
 COPY entrypoint.sh /entrypoint.sh

--- a/containers/webserver/httpd.conf
+++ b/containers/webserver/httpd.conf
@@ -547,7 +547,7 @@ LogLevel warn
 #Include conf/extra/httpd-dav.conf
 
 # Various default settings
-#Include conf/extra/httpd-default.conf
+Include conf/extra/httpd-default.conf
 
 # Configure mod_proxy_html to understand HTML4/XHTML1
 <IfModule proxy_html_module>


### PR DESCRIPTION
The header of Apache's `Server` header may also disclosure too much unnecessary information.

```sh
$ curl -sI --no-location http://lesspass.com | grep ^Server
Server: Apache/2.4.46 (Unix) OpenSSL/1.1.1d
```

cc #568