### PR TITLE
Remove trailing spaces in text files, following .editorconfig

### DIFF
--- a/bin/build_web_extensions
+++ b/bin/build_web_extensions
@@ -5,7 +5,7 @@ NOCOLOR='\033[0m'
 
 function print_error {
    echo -e "${RED}$1${NOCOLOR}"
-} 
+}
 
 function check_current_directory_is_root {
     if [ ! -f README.md ]; then
@@ -83,7 +83,7 @@ function increment_version {
 			patch=$((patch + 1))
 			;;
 	esac
-    
+
     new_version="$major.$minor.$patch"
     echo ${new_version}
 }

--- a/bin/build_web_site
+++ b/bin/build_web_site
@@ -5,7 +5,7 @@ NOCOLOR='\033[0m'
 
 function print_error {
    echo -e "${RED}$1${NOCOLOR}"
-} 
+}
 
 function check_current_directory_is_root {
     if [ ! -f README.md ]; then
@@ -83,7 +83,7 @@ function increment_version {
 			patch=$((patch + 1))
 			;;
 	esac
-    
+
     new_version="$major.$minor.$patch"
     echo ${new_version}
 }

--- a/cli/tests/test_functional.py
+++ b/cli/tests/test_functional.py
@@ -19,7 +19,7 @@ class TestFunctional(unittest.TestCase):
 
     def test_length_range_type(self):
         self.assertEqual(range_type('5'), 5)
-        self.assertEqual(range_type('35'), 35) 
+        self.assertEqual(range_type('35'), 35)
         with self.assertRaises(argparse.ArgumentTypeError):
             range_type('2')
 

--- a/containers/backend/Dockerfile
+++ b/containers/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6
 LABEL maintainer="LessPass <contact@lesspass.com>"
-LABEL name="LessPass Backend" 
+LABEL name="LessPass Backend"
 RUN mkdir /opt/backend
 WORKDIR /opt/backend
 COPY requirements.txt /opt/backend

--- a/containers/ssl/create_ca_and_ee.sh
+++ b/containers/ssl/create_ca_and_ee.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This script will create a custom Certificate Authority (CA) and End Entity (EE) certificates.
-# 
+#
 # for local development this should be fine and you can ignore certificate trust errors related to
 # an untrusted root. For public facing access, you can submit the generated lesspass.csr to a trusted
 # ca so that they can provide you with a trusted certificate to replace this development certificate.

--- a/containers/webserver/Dockerfile
+++ b/containers/webserver/Dockerfile
@@ -1,6 +1,6 @@
 FROM httpd:2.4
 LABEL maintainer="LessPass <contact@lesspass.com>"
-LABEL name="LessPass Web Server" 
+LABEL name="LessPass Web Server"
 
 COPY ./httpd-default.conf /usr/local/apache2/conf/extra/httpd-default.conf
 COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/mobile/android/app/src/main/java/com/lesspass/android/Crypto.java
+++ b/mobile/android/app/src/main/java/com/lesspass/android/Crypto.java
@@ -15,9 +15,9 @@ public class Crypto {
             byte[] secretData = secret.getBytes();
             byte[] saltData = salt.getBytes();
             gen.init(secretData, saltData, iterations);
-            byte[] derivedKey = ((KeyParameter)gen.generateDerivedParameters(keyLength * 8)).getKey();    
+            byte[] derivedKey = ((KeyParameter)gen.generateDerivedParameters(keyLength * 8)).getKey();
             return toHex(derivedKey);
-        } 
+        }
         catch (Exception e){
             throw new RuntimeException(e);
         }
@@ -32,7 +32,7 @@ public class Crypto {
             byte[] result = new byte[hmac.getMacSize()];
             hmac.doFinal(result, 0);
             return toHex(result);
-        } 
+        }
         catch (Exception e){
             throw new RuntimeException(e);
         }

--- a/mobile/ios/LessPassModule.swift
+++ b/mobile/ios/LessPassModule.swift
@@ -78,9 +78,9 @@ extension Data {
 }
 
 func pbkdf2(hash: CCPBKDFAlgorithm, password: String, salt: String, keyByteCount: Int, rounds: Int) -> String? {
- 
+
       guard let passwordData = password.data(using: .utf8), let saltData = salt.data(using: .utf8) else { return nil }
-  
+
     var derivedKeyData = Data(repeating: 0, count: keyByteCount)
     let derivedCount = derivedKeyData.count
     let derivationStatus: Int32 = derivedKeyData.withUnsafeMutableBytes { derivedKeyBytes in
@@ -111,7 +111,7 @@ class LessPassModule: NSObject {
                          rejecter reject:RCTPromiseRejectBlock) -> Void {
     resolve("".hmac(algorithm: HMACAlgorithm.SHA256, key: masterPassword))
   }
-  
+
   @objc(calcEntropy:withLogin:withMasterPassword:withCounter:resolver:rejecter:)
   func calcEntropy(_ site: String,
                    withLogin login: String,
@@ -123,7 +123,7 @@ class LessPassModule: NSObject {
     let r = pbkdf2(hash: CCPBKDFAlgorithm(kCCPRFHmacAlgSHA256), password: masterPassword, salt: salt, keyByteCount: 32, rounds: 100000)
     resolve(r)
   }
-  
+
   @objc
   static func requiresMainQueueSetup() -> Bool {
     return false

--- a/packages/lesspass-site/Dockerfile
+++ b/packages/lesspass-site/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts AS builder
 LABEL maintainer="LessPass <contact@lesspass.com>"
-LABEL name="LessPass Frontend" 
+LABEL name="LessPass Frontend"
 WORKDIR /opt/frontend
 COPY package.json yarn.lock ./
 RUN yarn install


### PR DESCRIPTION
Should better to integrate linter in CI to make sure the future changes also follows the `.editorconfig` for better styling.