### PR TITLE
Allow httpd*.conf under containers/webserver has trailing spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[containers/webserver/httpd*.conf]
+trim_trailing_whitespace = false
+
 [*.md]
 trim_trailing_whitespace = false
 


### PR DESCRIPTION
Current httpd*.conf files are copied from httpd:2.4 Docker official
images which has trailing spaces, but not added by the project, should
be ignored.