### PR TITLE
Fix shell script indentation as it's 4 spaces here

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ trim_trailing_whitespace = false
 
 [*.py]
 indent_size = 4
+
+[bin/*]
+indent_size = 4

--- a/bin/build_web_extensions
+++ b/bin/build_web_extensions
@@ -4,7 +4,7 @@ RED='\033[0;31m'
 NOCOLOR='\033[0m'
 
 function print_error {
-   echo -e "${RED}$1${NOCOLOR}"
+    echo -e "${RED}$1${NOCOLOR}"
 }
 
 function check_current_directory_is_root {
@@ -66,23 +66,23 @@ function increment_version {
     IFS='.' read -a versions <<< "${1}"
 
     major=${versions[0]}
-	minor=${versions[1]}
-	patch=${versions[2]}
+    minor=${versions[1]}
+    patch=${versions[2]}
 
-	case "${2}" in
-		"major")
-			major=$((major + 1))
-			minor=0
-			patch=0
-			;;
-		"minor")
-			minor=$((minor + 1))
-			patch=0
-			;;
-		"patch")
-			patch=$((patch + 1))
-			;;
-	esac
+    case "${2}" in
+        "major")
+            major=$((major + 1))
+            minor=0
+            patch=0
+            ;;
+        "minor")
+            minor=$((minor + 1))
+            patch=0
+            ;;
+        "patch")
+            patch=$((patch + 1))
+            ;;
+    esac
 
     new_version="$major.$minor.$patch"
     echo ${new_version}

--- a/bin/build_web_site
+++ b/bin/build_web_site
@@ -4,7 +4,7 @@ RED='\033[0;31m'
 NOCOLOR='\033[0m'
 
 function print_error {
-   echo -e "${RED}$1${NOCOLOR}"
+    echo -e "${RED}$1${NOCOLOR}"
 }
 
 function check_current_directory_is_root {
@@ -66,23 +66,23 @@ function increment_version {
     IFS='.' read -a versions <<< "${1}"
 
     major=${versions[0]}
-	minor=${versions[1]}
-	patch=${versions[2]}
+    minor=${versions[1]}
+    patch=${versions[2]}
 
-	case "${2}" in
-		"major")
-			major=$((major + 1))
-			minor=0
-			patch=0
-			;;
-		"minor")
-			minor=$((minor + 1))
-			patch=0
-			;;
-		"patch")
-			patch=$((patch + 1))
-			;;
-	esac
+    case "${2}" in
+        "major")
+            major=$((major + 1))
+            minor=0
+            patch=0
+            ;;
+        "minor")
+            minor=$((minor + 1))
+            patch=0
+            ;;
+        "patch")
+            patch=$((patch + 1))
+            ;;
+    esac
 
     new_version="$major.$minor.$patch"
     echo ${new_version}


### PR DESCRIPTION
There were few indents using 3 spaces or tabs in the shell scripts under `bin/` directory, looks like they should be 4 spaces as the most other places use 4 spaces.