### PR TITLE
Leave no Python pip temporary cache in backend Docker image

### DIFF
--- a/containers/backend/Dockerfile
+++ b/containers/backend/Dockerfile
@@ -4,8 +4,8 @@ LABEL name="LessPass Backend"
 RUN mkdir /opt/backend
 WORKDIR /opt/backend
 COPY requirements.txt /opt/backend
-RUN python -m pip install --upgrade pip
-RUN python -m pip install -r requirements.txt
+RUN python -m pip install --no-cache-dir --upgrade pip
+RUN python -m pip install --no-cache-dir -r requirements.txt
 COPY . /opt/backend
 RUN python --version
 EXPOSE 8000


### PR DESCRIPTION
This will make the backend image much smaller 🎉 

```
REPOSITORY                       TAG                IMAGE ID       CREATED          SIZE
after                            latest             ecd8a33f45fc   5 minutes ago    211MB
before                           latest             58b7dae3e4f0   13 minutes ago   235MB
```