### PR TITLE
ci: add python 3.10

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -17,6 +17,7 @@ jobs:
         python-version:
           - "3.6"
           - "3.8"
+          - "3.10"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Current pipeline test only agasint `3.6` and `3.8`

see #737