### PR TITLE
Update node.js to v14 in lesspass-site Dockerfile

### DIFF
--- a/packages/lesspass-site/Dockerfile
+++ b/packages/lesspass-site/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine AS builder
+FROM node:14-alpine AS builder
 LABEL maintainer="LessPass <contact@lesspass.com>"
 LABEL name="LessPass Frontend"
 WORKDIR /opt/frontend


### PR DESCRIPTION
The node version on CI for it in .github/workflows/containers-test.yml is v14, and it looks like it works well with node.js v14

This also syncs the nodejs version as the lesspass-website package is also using node.js v14