### PR TITLE
Update GitHub Actions env, replace EOL-ed Ubuntu 18.04 w/ Ubuntu 22.04

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/containers-publish.yml
+++ b/.github/workflows/containers-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: deploy containers

--- a/.github/workflows/containers-test.yml
+++ b/.github/workflows/containers-test.yml
@@ -12,7 +12,7 @@ on:
       - "packages/lesspass-site/**"
 jobs:
   test-backend:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -24,7 +24,7 @@ jobs:
           python -m pip install -r requirements.txt
           python manage.py test
   test-site:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -33,7 +33,7 @@ jobs:
       - run: yarn install
       - run: yarn workspace lesspass-site test
   test-integration:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: |

--- a/.github/workflows/lesspass-crypto-publish.yml
+++ b/.github/workflows/lesspass-crypto-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-crypto-test.yml
+++ b/.github/workflows/lesspass-crypto-test.yml
@@ -10,7 +10,7 @@ on:
       - "packages/lesspass-crypto/**"
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-entropy-publish.yml
+++ b/.github/workflows/lesspass-entropy-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-entropy-test.yml
+++ b/.github/workflows/lesspass-entropy-test.yml
@@ -10,7 +10,7 @@ on:
       - "packages/lesspass-entropy/**"
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-fingerprint-publish.yml
+++ b/.github/workflows/lesspass-fingerprint-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-fingerprint-test.yml
+++ b/.github/workflows/lesspass-fingerprint-test.yml
@@ -10,7 +10,7 @@ on:
       - "packages/lesspass-fingerprint/**"
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-publish.yml
+++ b/.github/workflows/lesspass-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-pure-publish.yml
+++ b/.github/workflows/lesspass-pure-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-pure-test.yml
+++ b/.github/workflows/lesspass-pure-test.yml
@@ -10,7 +10,7 @@ on:
       - "packages/lesspass-pure/**"
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-render-password-publish.yml
+++ b/.github/workflows/lesspass-render-password-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-render-password-test.yml
+++ b/.github/workflows/lesspass-render-password-test.yml
@@ -10,7 +10,7 @@ on:
       - "packages/lesspass-render-password/**"
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/lesspass-test.yml
+++ b/.github/workflows/lesspass-test.yml
@@ -10,7 +10,7 @@ on:
       - "packages/lesspass/**"
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/mobile-test.yml
+++ b/.github/workflows/mobile-test.yml
@@ -10,7 +10,7 @@ on:
       - "mobile/**"
 jobs:
   test-mobile:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Reference:

- https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/