### PR TITLE
Mobile: Fix keyboard navigation in PasswordGeneratorScreen

### DIFF
--- a/mobile/src/password/MasterPassword.js
+++ b/mobile/src/password/MasterPassword.js
@@ -57,6 +57,8 @@ export default class MasterPassword extends Component {
           value={masterPassword}
           secureTextEntry
           onChangeText={this.onChangeMasterPassword}
+          onSubmitEditing={this.props.onSubmitEditing}
+          outerRef={this.props.outerRef}
         />
         {masterPassword && fingerprint ? (
           <Fingerprint fingerprint={fingerprint} />

--- a/mobile/src/ui/TextInput.js
+++ b/mobile/src/ui/TextInput.js
@@ -12,6 +12,7 @@ export default function Input({ showError = false, errorText, ...props }) {
       }}
       style={{ marginBottom: 5 }}
       mode="outlined"
+      ref={props.outerRef}
       {...props}
     />
   );


### PR DESCRIPTION
This PR introduces UX enhancements to the password generator screen on mobile. The updates to the `PasswordGeneratorScreen` include:
- Auto-focus on the 'site' input field.
- The next button on the keyboard shifts focus to the subsequent text input.
- The done button on the master password field (last text input) triggers password generation.

fixes #778 