### PR TITLE
Add @react-native-async-storage/async-storage Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
       "**/lesspass-pure"
     ]
   },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.0.0"  // Use the latest version available
+  },
   "devDependencies": {
     "@types/jest": "^27.0.3",
     "browserify": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ]
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.0.0"  // Use the latest version available
+    "@react-native-async-storage/async-storage": "^1.0.0"  
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",


### PR DESCRIPTION
This pull request adds @react-native-async-storage/async-storage to the dependencies section of package.json. This update is necessary due to recent changes in the project that require the use of AsyncStorage from the @react-native-async-storage/async-storage package, replacing the previous @react-native-community/async-storage package.

Changes:

Added @react-native-async-storage/async-storage to the dependencies section of package.json.
Ensured that the package version is set to ^1.0.0 to use the latest stable release.
Rationale:

The project previously used @react-native-community/async-storage, which is now deprecated. The migration to @react-native-async-storage/async-storage aligns with the latest standards and maintains compatibility with the current React Native version.

Impact:

This change will ensure that the project uses the updated and supported AsyncStorage package.
No additional code changes are included in this pull request, but ensure that all import statements for AsyncStorage are updated to reflect the new package if not already done.
Instructions:

Update package.json with the new dependency.
Run yarn install to install the new package.
Verify that the application and tests work correctly with the new dependency.