### PR TITLE
docs: correct link to issue page on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are also [alternative server implementations](https://github.com/lesspass/
 
 ## Questions
 
-If you have any questions, create an [issue](issue).
+If you have any questions, create an [issue](https://github.com/lesspass/lesspass/issues/new/).
 Protip: do a quick search first to see if someone else has asked the same question before!
 
 You can also reach me at contact@lesspass.com


### PR DESCRIPTION
fixes #854 use absolute URL