### PR TITLE
fix: Windows test suite compatibility

### DIFF
--- a/cli/tests/cli_test_helpers.py
+++ b/cli/tests/cli_test_helpers.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+CORE_PY = Path(__file__).resolve().parent.parent / "lesspass" / "core.py"
+
+def run_lesspass(*args, interactive=False):
+    kwargs = dict(
+        args = [sys.executable, str(CORE_PY), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=CORE_PY.parent
+    )
+
+    if interactive :
+        kwargs["stdin"]=subprocess.PIPE
+        if sys.platform == "win32":
+            kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP |
+                subprocess.CREATE_NO_WINDOW
+            )
+        return subprocess.Popen(**kwargs)
+    
+    result = subprocess.run(**kwargs, text=True, timeout=5)
+    return result.stdout + result.stderr

--- a/cli/tests/cli_test_helpers.py
+++ b/cli/tests/cli_test_helpers.py
@@ -2,25 +2,30 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 CORE_PY = Path(__file__).resolve().parent.parent / "lesspass" / "core.py"
 
-def run_lesspass(*args, interactive=False):
-    kwargs = dict(
-        args = [sys.executable, str(CORE_PY), *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=CORE_PY.parent
-    )
 
-    if interactive :
-        kwargs["stdin"]=subprocess.PIPE
+def run_lesspass(*args, interactive=False, timeout=5):
+    kwargs = {
+        "args": [sys.executable, str(CORE_PY), *args],
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "cwd": CORE_PY.parent,
+        "text": True,
+    }
+
+    if interactive:
+        kwargs["stdin"] = subprocess.PIPE
+
         if sys.platform == "win32":
             kwargs["creationflags"] = (
-                subprocess.CREATE_NEW_PROCESS_GROUP |
-                subprocess.CREATE_NO_WINDOW
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
             )
-        return subprocess.Popen(**kwargs)
-    
-    result = subprocess.run(**kwargs, text=True, timeout=5)
-    return result.stdout + result.stderr
+
+    process = subprocess.Popen(**kwargs)
+
+    if interactive:
+        return process
+
+    stdout, stderr = process.communicate(timeout=timeout)
+    return stdout + stderr

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import patch
 
@@ -125,7 +126,8 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(parse_args(["site"]).save_path, None)
         with patch.dict("os.environ", {"XDG_CONFIG_HOME": "/tmp"}):
             self.assertEqual(
-                parse_args(["--save"]).save_path, "/tmp/lesspass/profiles.json"
+                parse_args(["--save"]).save_path, 
+                os.path.join("/tmp", "lesspass", "profiles.json")
             )
 
     def test_parse_args_load_path(self):
@@ -135,13 +137,13 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(parse_args(["site"]).load_path, None)
 
     def test_parse_args_config_home_path(self):
-        self.assertTrue(parse_args([]).config_home_path.endswith("/.config/lesspass"))
+        self.assertTrue(parse_args([]).config_home_path.endswith(os.path.join(".config", "lesspass")))
 
     def test_parse_args_XDG_CONFIG_HOME_env_variable(self):
         with patch.dict("os.environ", {"XDG_CONFIG_HOME": "/tmp"}):
-            self.assertEqual(parse_args([]).config_home_path, "/tmp/lesspass")
+            self.assertEqual(parse_args([]).config_home_path, os.path.join("/tmp", "lesspass"))
 
-    def test_parse_args_default_base_url(self):
+    def test_parse_args_default_base_url_is_lesspass(self):
         self.assertEqual(parse_args([]).url, "https://api.lesspass.com/")
 
     def test_parse_args_default_base_url(self):

--- a/cli/tests/test_functional.py
+++ b/cli/tests/test_functional.py
@@ -6,6 +6,13 @@ import sys
 import argparse
 from lesspass.cli import range_type
 
+class TestRangeType(unittest.TestCase):
+    def test_length_range_type(self):
+        self.assertEqual(range_type("5"), 5)
+        self.assertEqual(range_type("35"), 35)
+        with self.assertRaises(argparse.ArgumentTypeError):
+            range_type("2")
+
 @unittest.skipIf(sys.platform == "win32", "pexpect.spawn is not supported on Windows")
 class TestFunctional(unittest.TestCase):
     def test_length_below_the_minimum(self):
@@ -17,12 +24,6 @@ class TestFunctional(unittest.TestCase):
         self.assertTrue(
             "error: argument -L/--length: 2 is out of range, choose in [5-35]" in output
         )
-
-    def test_length_range_type(self):
-        self.assertEqual(range_type("5"), 5)
-        self.assertEqual(range_type("35"), 35)
-        with self.assertRaises(argparse.ArgumentTypeError):
-            range_type("2")
 
     def test_exclude_chars_not_in_output(self):
         p = pexpect.spawn(

--- a/cli/tests/test_functional.py
+++ b/cli/tests/test_functional.py
@@ -1,11 +1,12 @@
 import unittest
 import pexpect
+import sys
 
 
 import argparse
 from lesspass.cli import range_type
 
-
+@unittest.skipIf(sys.platform == "win32", "pexpect.spawn is not supported on Windows")
 class TestFunctional(unittest.TestCase):
     def test_length_below_the_minimum(self):
         p = pexpect.spawn(
@@ -23,7 +24,7 @@ class TestFunctional(unittest.TestCase):
         with self.assertRaises(argparse.ArgumentTypeError):
             range_type("2")
 
-    def test_exclude(self):
+    def test_exclude_chars_not_in_output(self):
         p = pexpect.spawn(
             'python3 lesspass/core.py  site login masterpassword --exclude "!@$*+-8"'
         )
@@ -31,7 +32,7 @@ class TestFunctional(unittest.TestCase):
         for c in "!@$*+-8":
             self.assertTrue(c not in output)
 
-    def test_exclude(self):
+    def test_exclude_all_chars(self):
         p = pexpect.spawn(
             'python3 lesspass/core.py  site login masterpassword -d -L6 --exclude "0123456789"'
         )

--- a/cli/tests/test_functional.py
+++ b/cli/tests/test_functional.py
@@ -1,42 +1,56 @@
 import unittest
-import pexpect
+import subprocess
 import sys
-
-
 import argparse
+from pathlib import Path
 from lesspass.cli import range_type
 
+# Path to core.py, anchored to this file's location so tests run from any directory
+CORE_PY = Path(__file__).resolve().parent.parent / "lesspass" / "core.py"
+
+def run_lesspass(*args):
+    # Spawns core.py as a subprocess and returns its combined stdout+stderr
+    # as a string
+    result = subprocess.run(
+        [sys.executable, str(CORE_PY), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=CORE_PY.parent,
+    )
+    return result.stdout + result.stderr
+
 class TestRangeType(unittest.TestCase):
-    def test_length_range_type(self):
+    def test_valid_values(self):
         self.assertEqual(range_type("5"), 5)
         self.assertEqual(range_type("35"), 35)
+
+    def test_below_minimum_raises(self):
         with self.assertRaises(argparse.ArgumentTypeError):
             range_type("2")
 
-@unittest.skipIf(sys.platform == "win32", "pexpect.spawn is not supported on Windows")
 class TestFunctional(unittest.TestCase):
-    def test_length_below_the_minimum(self):
-        p = pexpect.spawn(
-            "python3 lesspass/core.py  site login masterpassword --lowercase --digits --length 2"
-        )
-        output = p.read().decode()
 
-        self.assertTrue(
-            "error: argument -L/--length: 2 is out of range, choose in [5-35]" in output
+    def test_length_below_the_minimum(self):
+        output = run_lesspass(
+            "site", "login", "masterpassword",
+            "--lowercase", "--digits", "--length", "2",
+        )
+        self.assertIn(
+            "error: argument -L/--length: 2 is out of range, choose in [5-35]",
+            output,
         )
 
     def test_exclude_given_chars_from_output(self):
-        p = pexpect.spawn(
-            'python3 lesspass/core.py  site login masterpassword --exclude "!@$*+-8"'
+        output = run_lesspass(
+            "site", "login", "masterpassword", "--exclude", "!@$*+-8",
         )
-        output = p.read().decode()
         for c in "!@$*+-8":
-            self.assertTrue(c not in output)
+            self.assertNotIn(c, output)
 
     def test_exclude_all_chars_raise_error(self):
-        p = pexpect.spawn(
-            'python3 lesspass/core.py  site login masterpassword -d -L6 --exclude "0123456789"'
+        output = run_lesspass(
+            "site", "login", "masterpassword",
+            "-d", "-L6", "--exclude", "0123456789",
         )
-        output = p.read().decode()
-
-        self.assertTrue("error: you can't exclude all chars available" in output)
+        self.assertIn("error: you can't exclude all chars available", output)

--- a/cli/tests/test_functional.py
+++ b/cli/tests/test_functional.py
@@ -1,24 +1,8 @@
 import unittest
-import subprocess
-import sys
 import argparse
-from pathlib import Path
+from .cli_test_helpers import run_lesspass
 from lesspass.cli import range_type
 
-# Path to core.py, anchored to this file's location so tests run from any directory
-CORE_PY = Path(__file__).resolve().parent.parent / "lesspass" / "core.py"
-
-def run_lesspass(*args):
-    # Spawns core.py as a subprocess and returns its combined stdout+stderr
-    # as a string
-    result = subprocess.run(
-        [sys.executable, str(CORE_PY), *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=CORE_PY.parent,
-    )
-    return result.stdout + result.stderr
 
 class TestRangeType(unittest.TestCase):
     def test_valid_values(self):

--- a/cli/tests/test_functional.py
+++ b/cli/tests/test_functional.py
@@ -25,7 +25,7 @@ class TestFunctional(unittest.TestCase):
             "error: argument -L/--length: 2 is out of range, choose in [5-35]" in output
         )
 
-    def test_exclude_chars_not_in_output(self):
+    def test_exclude_given_chars_from_output(self):
         p = pexpect.spawn(
             'python3 lesspass/core.py  site login masterpassword --exclude "!@$*+-8"'
         )
@@ -33,7 +33,7 @@ class TestFunctional(unittest.TestCase):
         for c in "!@$*+-8":
             self.assertTrue(c not in output)
 
-    def test_exclude_all_chars(self):
+    def test_exclude_all_chars_raise_error(self):
         p = pexpect.spawn(
             'python3 lesspass/core.py  site login masterpassword -d -L6 --exclude "0123456789"'
         )

--- a/cli/tests/test_interaction.py
+++ b/cli/tests/test_interaction.py
@@ -1,8 +1,10 @@
 import unittest
 import pexpect
 import signal
+import sys
 
 
+@unittest.skipIf(sys.platform == "win32", "pexpect.spawn is not supported on Windows")
 class TestInteraction(unittest.TestCase):
     def test_keyboard_interrupt(self):
         p = pexpect.spawn("python3 lesspass/core.py --prompt")

--- a/cli/tests/test_interaction.py
+++ b/cli/tests/test_interaction.py
@@ -2,28 +2,13 @@ import unittest
 import subprocess
 import signal
 import sys
-from pathlib import Path
+from .cli_test_helpers import run_lesspass
 
-# Path to core.py, anchored to this file's location so tests run from any directory
-CORE_PY = Path(__file__).resolve().parent.parent / "lesspass" / "core.py"
 
 class TestInteraction(unittest.TestCase):
     def test_keyboard_interrupt(self):
-        kwargs = {}
-        if sys.platform == "win32":
-            kwargs["creationflags"] = (
-                subprocess.CREATE_NEW_PROCESS_GROUP |
-                subprocess.CREATE_NO_WINDOW
-            )
-
-        p = subprocess.Popen(
-            [sys.executable, str(CORE_PY), "--prompt"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-            cwd=CORE_PY.parent,
-            **kwargs,
-        )
+        
+        p = run_lesspass("--prompt", interactive=True)
 
         if sys.platform == "win32":
             p.send_signal(signal.CTRL_C_EVENT)

--- a/cli/tests/test_interaction.py
+++ b/cli/tests/test_interaction.py
@@ -1,14 +1,39 @@
 import unittest
-import pexpect
+import subprocess
 import signal
 import sys
+from pathlib import Path
 
+# Path to core.py, anchored to this file's location so tests run from any directory
+CORE_PY = Path(__file__).resolve().parent.parent / "lesspass" / "core.py"
 
-@unittest.skipIf(sys.platform == "win32", "pexpect.spawn is not supported on Windows")
 class TestInteraction(unittest.TestCase):
     def test_keyboard_interrupt(self):
-        p = pexpect.spawn("python3 lesspass/core.py --prompt")
-        p.expect("Site: ")
-        p.kill(signal.SIGINT)
-        p.expect(pexpect.EOF)
-        self.assertEqual(p.before, b"")
+        kwargs = {}
+        if sys.platform == "win32":
+            kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP |
+                subprocess.CREATE_NO_WINDOW
+            )
+
+        p = subprocess.Popen(
+            [sys.executable, str(CORE_PY), "--prompt"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            cwd=CORE_PY.parent,
+            **kwargs,
+        )
+
+        if sys.platform == "win32":
+            p.send_signal(signal.CTRL_C_EVENT)
+        else:
+            p.send_signal(signal.SIGINT)
+
+        try:
+            stdout, stderr = p.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            stdout, stderr = p.communicate()
+
+        self.assertEqual(stdout, b"")

--- a/cli/tests/test_interaction.py
+++ b/cli/tests/test_interaction.py
@@ -21,4 +21,4 @@ class TestInteraction(unittest.TestCase):
             p.kill()
             stdout, stderr = p.communicate()
 
-        self.assertEqual(stdout, b"")
+        self.assertEqual(stdout, "")


### PR DESCRIPTION
Fixes #866

While running the test suite on Windows (Python 3.13.2) I found several 
failures caused by the tests assuming a Unix environment.

## Changes

**Duplicate test methods (fixes #866)**
- Renamed duplicate `test_parse_args_default_base_url` in `test_cli.py`
- Renamed duplicate `test_exclude` methods in `test_functional.py` as suggested 
   by @edouard-lopez

**Hardcoded Unix path separators**
- Fixed 3 tests in `test_cli.py` that hardcoded forward slashes in path 
assertions, replaced with `os.path.join()` so they work cross-platform

**pexpect.spawn not available on Windows**
- After @edouard-lopez suggested avoiding skipping tests and with the input of @rh-gvincent, went with
  `subprocess` instead as it removes the `pexpect` dependency entirely
- `subprocess` is part of the standard library — no third-party dependency needed
- Handles signals cross-platform: `SIGINT` on Linux/macOS, `CTRL_C_EVENT` on Windows
- `cli_test_helpers.py` created as a shared test utility that centralizes the `run_lesspass()` helper, avoiding code duplication across test_functional.py and test_interaction.py
- No `@skipIf` needed — all tests now run on all platforms

## Test results on Windows 11, Python 3.13.2
Before: 6 failed, 79 passed
After:  88 passed, 0 skipped, 0 failed