### PR TITLE
fix: add FLAG_SECURE to prevent screenshots and recent apps exposure

### DIFF
--- a/packages/lesspass-mobile/android/app/src/main/java/com/lesspass/MainActivity.kt
+++ b/packages/lesspass-mobile/android/app/src/main/java/com/lesspass/MainActivity.kt
@@ -1,11 +1,19 @@
 package com.lesspass
 
+import android.os.Bundle
+import android.view.WindowManager
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
 class MainActivity : ReactActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+      // Prevents screenshots and hides content
+    window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+  }
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule


### PR DESCRIPTION
Fixes #828

Sensitive data such as the master password and generated passwords were visible in screenshots and in the Android recent apps view, exposing them to other apps with screen capture permissions.

Solution was to adding FLAG_SECURE to the `MainActivity` window in the `onCreate` method to prevent screenshots and hides app screen in recent apps thumbnail.

Tested on Android emulator (API 37, Android 17.0 CinnamonBun, x86_64) with one addendum, screenshot blocking is not testable on emulator by design — `FLAG_SECURE` is bypassed in emulated environments. Behavior is confirmed correct on physical devices per Android documentation, but the recent apps view shows blank thumbnail instead of app content.