### PR TITLE
Fixes error message on server URL sign in form

### DIFF
--- a/packages/lesspass-web-component/src/auth/SignInForm.tsx
+++ b/packages/lesspass-web-component/src/auth/SignInForm.tsx
@@ -44,7 +44,7 @@ export default function SignInForm({
           {t("SignInForm.LessPassServer")}
         </Label>
         <Input id="sign-in-form__baseUrl" {...register("baseUrl")} />
-        <ErrorMessage message={errors.email?.message} />
+        <ErrorMessage message={errors.baseUrl?.message} />
       </Field>
       <Field>
         <Label htmlFor="username">{t("SignInForm.Email")}</Label>


### PR DESCRIPTION

Really really minor tiny issue. But I noticed that when signing in, the validation error from the email field was showing up in the server field's area.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/3e5f9f30-fb09-46e1-aa32-79ce4b80e2ff" />

I didn't want to bother you by submitting a bug report for something so small
it's just a 1-line update :)

```diff
- <ErrorMessage message={errors.email?.message} />
+ <ErrorMessage message={errors.baseUrl?.message} />
```